### PR TITLE
Add mcp-get installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ npm run watch
 
 ## Installation
 
+### Using mcp-get
+
+You can install this package using mcp-get:
+
+```bash
+npx @michaellatman/mcp-get@latest install mcp-mongo-server
+```
+
+### Using Claude Desktop
+
 To use with Claude Desktop, add the server config:
 
 On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`


### PR DESCRIPTION
Add mcp-get installation instructions

Add documentation for installing the package using mcp-get. This makes it easier for users to discover and install the package through the mcp-get package manager.

Changes:
- Add section for mcp-get installation under Installation
- Include correct command format with @latest tag
- Maintain consistent documentation style and hierarchy
