### PR TITLE
feat: implement read-only mode for MongoDB connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ A Model Context Protocol server that provides access to MongoDB databases. This 
 
 ## Features
 
+### Read-Only Mode
+- Connect to MongoDB in read-only mode with `--read-only` or `-r` flag
+- Prevents write operations (update, insert, createIndex)
+- Uses MongoDB's secondary read preference for optimal read performance
+- Provides additional safety for production database connections
+
 ### Resources
 - List and access collections via `mongodb://` URIs
 - Each collection has a name, description and schema
@@ -97,6 +103,14 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
         "mongodb://muhammed:kilic@mongodb.localhost/namespace"
       ]
     },
+    "mongodb-readonly": {
+      "command": "node",
+      "args": [
+        "~/mcp-mongo-server/build/index.js",
+        "mongodb://muhammed:kilic@mongodb.localhost/namespace",
+        "--read-only"
+      ]
+    }
   }
 }
 ```
@@ -139,6 +153,15 @@ To use this server with the Claude Desktop app, add the following configuration 
         "mcp-mongo-server",
         "mongodb://muhammed:kilic@mongodb.localhost/sample_namespace"
       ]
+    },
+    "mongodb-readonly": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-mongo-server",
+        "mongodb://muhammed:kilic@mongodb.localhost/sample_namespace",
+        "--read-only"
+      ]
     }
   }
 }
@@ -161,6 +184,21 @@ npx @michaellatman/mcp-get@latest install mcp-mongo-server
 ```
 
 Replace `/sample_namespace` with your database name.
+
+## Using Read-Only Mode
+
+You can connect to MongoDB in read-only mode by adding the `--read-only` or `-r` flag when starting the server. This is recommended when you need to protect your data from accidental writes or when connecting to production databases.
+
+```bash
+# Connect in read-only mode using the command line
+npx mcp-mongo-server mongodb://user:password@mongodb.example.com/database --read-only
+```
+
+When in read-only mode:
+1. All write operations (update, insert, createIndex) will be blocked
+2. The server connects using MongoDB's secondary read preference
+3. The connection status indicates read-only mode is active
+4. The `ping` and `serverInfo` responses include read-only status information
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
   ListResourceTemplatesRequestSchema,
   PingRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { MongoClient } from "mongodb";
+import { MongoClient, ReadPreference } from "mongodb";
 import { MongoCollection } from "./types.js";
 
 /**
@@ -29,6 +29,10 @@ import { MongoCollection } from "./types.js";
  */
 let client: MongoClient | null = null;
 let db: any = null;
+/**
+ * Flag indicating whether the connection is in read-only mode
+ */
+let isReadOnlyMode = false;
 
 /**
  * Create an MCP server with capabilities for resources (to list/read collections),
@@ -51,11 +55,13 @@ const server = new Server(
 /**
  * Initialize MongoDB connection
  */
-async function connectToMongoDB(url: string) {
+async function connectToMongoDB(url: string, readOnly: boolean = false) {
   try {
-    client = new MongoClient(url);
+    const options = readOnly ? { readPreference: ReadPreference.SECONDARY } : {};
+    client = new MongoClient(url, options);
     await client.connect();
     db = client.db();
+    isReadOnlyMode = readOnly;
     return true;
   } catch (error) {
     console.error("Failed to connect to MongoDB:", error);
@@ -76,7 +82,9 @@ server.setRequestHandler(PingRequestSchema, async () => {
     // Ping MongoDB to verify connection
     await db.command({ ping: 1 });
 
-    return {};
+    return {
+      readOnlyMode: isReadOnlyMode
+    };
   } catch (error) {
     if (error instanceof Error) {
       throw new Error(`MongoDB ping failed: ${error.message}`);
@@ -449,6 +457,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
  */
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const collection = db.collection(request.params.arguments?.collection);
+  
+  // Define write operations that should be blocked in read-only mode
+  const writeOperations = ['update', 'insert', 'createIndex'];
+  
+  // Check if the operation is a write operation and we're in read-only mode
+  if (isReadOnlyMode && writeOperations.includes(request.params.name)) {
+    throw new Error(`Operation '${request.params.name}' is not allowed in read-only mode`);
+  }
 
   switch (request.params.name) {
     case "query": {
@@ -714,6 +730,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           bits: buildInfo.bits,
           ok: buildInfo.ok,
           status: {},
+          connectionInfo: {
+            readOnlyMode: isReadOnlyMode,
+            readPreference: isReadOnlyMode ? 'secondary' : 'primary'
+          }
         };
 
         // Add server status information if requested
@@ -1181,14 +1201,28 @@ Use these patterns to construct MongoDB queries.`,
  */
 async function main() {
   const args = process.argv.slice(2);
-  if (args.length === 0) {
+  let connectionUrl = '';
+  let readOnlyMode = false;
+  
+  // Parse command line arguments
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--read-only' || args[i] === '-r') {
+      readOnlyMode = true;
+    } else if (!connectionUrl) {
+      connectionUrl = args[i];
+    }
+  }
+  
+  if (!connectionUrl) {
     console.error(
-      "Please provide a MongoDB connection URL as a command-line argument",
+      "Please provide a MongoDB connection URL as a command-line argument"
     );
+    console.error("Usage: command <mongodb-url> [--read-only|-r]");
     process.exit(1);
   }
 
-  const connected = await connectToMongoDB(args[0]);
+  console.log(`Connecting to MongoDB${readOnlyMode ? ' in read-only mode' : ''}...`);
+  const connected = await connectToMongoDB(connectionUrl, readOnlyMode);
   if (!connected) {
     console.error("Failed to connect to MongoDB");
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -463,7 +463,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   
   // Check if the operation is a write operation and we're in read-only mode
   if (isReadOnlyMode && writeOperations.includes(request.params.name)) {
-    throw new Error(`Operation '${request.params.name}' is not allowed in read-only mode`);
+    throw new Error(`ReadonlyError: Operation '${request.params.name}' is not allowed in read-only mode`);
   }
 
   switch (request.params.name) {


### PR DESCRIPTION
- Added support for connecting to MongoDB in read-only mode using the `--read-only` or `-r` flag.
- Updated README with instructions and examples for using read-only mode.