### PR TITLE
Fix output not JSON

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1221,7 +1221,6 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`Connecting to MongoDB${readOnlyMode ? ' in read-only mode' : ''}...`);
   const connected = await connectToMongoDB(connectionUrl, readOnlyMode);
   if (!connected) {
     console.error("Failed to connect to MongoDB");


### PR DESCRIPTION
Removed the console.log() line that causes Claude Desktop to report an error as the output is not JSON as expected.