### PR TITLE
Lean serverInfo output by default and CI action updates

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -33,9 +33,9 @@ jobs:
       BUILD_ID: ${{ github.run_number }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -694,37 +694,32 @@ async function handleServerInfo(
     signal?.throwIfAborted();
     const buildInfo = await db.command({ buildInfo: 1 });
 
-    // Get additional server status if debug info is requested
-    let serverStatus = null;
-    if (includeDebugInfo) {
-      signal?.throwIfAborted();
-      serverStatus = await db.command({ serverStatus: 1 });
-    }
-
-    // Construct the response
-    const serverInfo = {
+    // Lean response by default; verbose build/runtime details (compiler
+    // flags, server status) are large and only returned on explicit request
+    const serverInfo: Record<string, unknown> = {
       version: buildInfo.version,
       gitVersion: buildInfo.gitVersion,
-      modules: buildInfo.modules,
-      allocator: buildInfo.allocator,
-      javascriptEngine: buildInfo.javascriptEngine,
-      sysInfo: buildInfo.sysInfo,
       storageEngines: buildInfo.storageEngines,
-      debug: buildInfo.debug,
       maxBsonObjectSize: buildInfo.maxBsonObjectSize,
-      openssl: buildInfo.openssl,
-      buildEnvironment: buildInfo.buildEnvironment,
       bits: buildInfo.bits,
       ok: buildInfo.ok,
-      status: {},
       connectionInfo: {
         readOnlyMode: isReadOnlyMode,
         readPreference: isReadOnlyMode ? "secondary" : "primary",
       },
     };
 
-    // Add server status information if requested
-    if (serverStatus) {
+    if (includeDebugInfo) {
+      signal?.throwIfAborted();
+      const serverStatus = await db.command({ serverStatus: 1 });
+
+      serverInfo.modules = buildInfo.modules;
+      serverInfo.allocator = buildInfo.allocator;
+      serverInfo.javascriptEngine = buildInfo.javascriptEngine;
+      serverInfo.sysInfo = buildInfo.sysInfo;
+      serverInfo.debug = buildInfo.debug;
+      serverInfo.openssl = buildInfo.openssl;
+      serverInfo.buildEnvironment = buildInfo.buildEnvironment;
       serverInfo.status = {
         host: serverStatus.host,
         version: serverStatus.version,


### PR DESCRIPTION
## Summary

Two small maintenance improvements.

### Lean `serverInfo` output

The default `serverInfo` response previously included the full `buildEnvironment` block (compiler and linker flags), consuming thousands of tokens per call while providing no value to LLM agents. The response now contains only the essentials — `version`, `gitVersion`, `storageEngines`, `maxBsonObjectSize`, `bits`, `ok` and `connectionInfo` — cutting the default payload from ~3.7k to ~300 characters.

Verbose details (`buildEnvironment`, `openssl`, `allocator`, `modules` and the full `serverStatus` block) are still available when explicitly requested via `includeDebugInfo: true`.

### CI

Updated `actions/checkout` and `actions/setup-node` from v4 to v5 in both publish workflows, resolving the Node 20 deprecation warnings emitted during the 2.1.0 release run.

## Testing

- Verified both modes live against MongoDB 8.2 (replica set + auth) over stdio JSON-RPC: default response 288 characters with lean fields only; `includeDebugInfo: true` returns the full payload including `buildEnvironment` and `serverStatus`.
- Typecheck and build clean.