### PR TITLE
Migrate to MCP SDK v2 (dual-era) + security hardening + convertTime — v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,51 +5,105 @@
 ![NPM Downloads](https://img.shields.io/npm/dm/mcp-mongo-server)
 ![NPM License](https://img.shields.io/npm/l/mcp-mongo-server)
 
-A Model Context Protocol server that enables LLMs to interact with MongoDB databases. This server provides capabilities for inspecting collection schemas and executing MongoDB operations through a standardized interface.
+A Model Context Protocol (MCP) server that lets AI assistants work with your MongoDB databases. It exposes your collections, infers their schemas, and runs queries, aggregations, and writes through a standard interface — so tools like Claude Desktop and Cursor can read and reason about your data.
 
 ## Demo
 
 [![MCP MongoDB Server Demo | Claude Desktop](https://img.youtube.com/vi/FI-oE_voCpA/0.jpg)](https://www.youtube.com/watch?v=FI-oE_voCpA)
 
+## Why use it
+
+- **Talk to your database in plain language** — the assistant discovers your collections and their shape automatically.
+- **Safe by default** — turn on read-only mode to let an assistant explore without any risk of changing data.
+- **Works everywhere** — connects to standalone, replica set, sharded, and Atlas deployments, over plain or TLS connections.
+
 ## Key Features
 
-- **Smart ObjectId Handling** - Configurable auto/none/force modes for string-to-ObjectId conversion
-- **Read-Only Mode** - Protection against write operations, uses secondary read preference
-- **Schema Inference** - Automatic collection schema detection from document samples
-- **Query & Aggregation** - Full MongoDB query and aggregation pipeline support with optional explain plans
-- **Write Operations** - Insert, update, and index creation (when not in read-only mode)
-- **Collection Completions** - Auto-complete collection names for LLM integration
+- **Read-Only Mode** — blocks every write path (insert, update, index creation, and aggregation stages like `$out`/`$merge` that could modify data).
+- **Smart ObjectId Handling** — configurable `auto`/`none`/`force` conversion of 24-character hex strings to ObjectIds.
+- **Schema Inference** — automatic collection schema detection from document samples.
+- **Query & Aggregation** — full query and aggregation pipeline support, with optional `explain` plans.
+- **Write Operations** — insert, update, and index creation (when read-only mode is off).
+- **Progress & Cancellation** — long operations report progress and can be cancelled mid-flight.
+- **Two Transports** — run locally over stdio, or expose an HTTP endpoint for remote access.
 
-## Installation
+## Requirements
+
+- Node.js 20 or newer
+
+## Quick Start
+
+Point the server at your database — no install step needed:
 
 ```bash
-npx -y mcp-mongo-server mongodb://localhost:27017/database
+npx -y mcp-mongo-server mongodb://localhost:27017/mydatabase
+```
+
+Explore safely, without any chance of changing data:
+
+```bash
+npx -y mcp-mongo-server mongodb://localhost:27017/mydatabase --read-only
 ```
 
 ## Usage
 
-```bash
-# Start server with MongoDB URI
-npx -y mcp-mongo-server mongodb://muhammed:kilic@localhost:27017/database
+### Local (stdio)
 
-# Connect in read-only mode
-npx -y mcp-mongo-server mongodb://muhammed:kilic@localhost:27017/database --read-only
+This is the default, used by Claude Desktop, Cursor, and other local clients:
+
+```bash
+npx -y mcp-mongo-server "mongodb://user:pass@localhost:27017/mydatabase"
 ```
+
+### Remote (HTTP)
+
+Expose an HTTP endpoint at `/mcp` for remote or multi-client access:
+
+```bash
+npx -y mcp-mongo-server "mongodb://user:pass@localhost:27017/mydatabase" --transport http --port 3001
+```
+
+By default, only requests without a browser `Origin` (CLIs, IDEs) and requests
+from `localhost` are accepted; everything else is rejected with `403` to guard
+against DNS-rebinding attacks. Allow specific browser origins with
+`--allowed-origins`:
+
+```bash
+npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-origins "https://app.example.com"
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--read-only`, `-r` | Block all write operations |
+| `--transport`, `-t` | `stdio` (default) or `http` |
+| `--port`, `-p` | HTTP port (default `3001`) |
+| `--allowed-origins` | Comma-separated browser origins to allow in HTTP mode |
 
 ### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `MCP_MONGODB_URI` | MongoDB connection URI |
+| `MCP_MONGODB_URI` | MongoDB connection URI (alternative to the argument) |
 | `MCP_MONGODB_READONLY` | Enable read-only mode (`"true"`) |
+| `MCP_PORT` | HTTP port |
+| `MCP_HTTP_ALLOWED_ORIGINS` | Comma-separated browser origins to allow in HTTP mode |
+
+## Security
+
+Read-only mode is enforced inside the server, which is enough for most setups.
+For a hard guarantee that nothing can ever write — regardless of the tool —
+connect with a MongoDB user that only has read permissions. That way the
+database itself rejects any write, as defense in depth.
 
 ## Documentation
 
-- [Integration Guide](docs/integration.md) - Claude Desktop, Windsurf, Cursor, Docker
-- [Available Tools](docs/tools.md) - Query, aggregate, update, insert, and more
-- [Development](docs/development.md) - Setup, scripts, and debugging
+- [Integration Guide](docs/integration.md) — Claude Desktop, Windsurf, Cursor, Docker
+- [Available Tools](docs/tools.md) — query, aggregate, update, insert, and more
+- [Development](docs/development.md) — setup, scripts, and debugging
 - [Contributing](CONTRIBUTING.md)
 
 ## License
 
-MIT - see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-o
 | Flag | Description |
 |------|-------------|
 | `--read-only`, `-r` | Block all write operations |
+| `--allow-cross-db` | Allow aggregation `$out`/`$merge`/`$lookup` to target other databases (off by default) |
 | `--transport`, `-t` | `stdio` (default) or `http` |
 | `--port`, `-p` | HTTP port (default `3001`) |
 | `--allowed-origins` | Comma-separated browser origins to allow in HTTP mode |
+| `--json-limit` | Max HTTP request body size (default `10mb`) |
 
 ### Environment Variables
 
@@ -87,15 +89,28 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-o
 |----------|-------------|
 | `MCP_MONGODB_URI` | MongoDB connection URI (alternative to the argument) |
 | `MCP_MONGODB_READONLY` | Enable read-only mode (`"true"`) |
+| `MCP_MONGODB_ALLOW_CROSS_DB` | Allow cross-database aggregation stages (`"true"`) |
 | `MCP_PORT` | HTTP port |
 | `MCP_HTTP_ALLOWED_ORIGINS` | Comma-separated browser origins to allow in HTTP mode |
+| `MCP_HTTP_JSON_LIMIT` | Max HTTP request body size (default `10mb`) |
 
 ## Security
 
-Read-only mode is enforced inside the server, which is enough for most setups.
-For a hard guarantee that nothing can ever write — regardless of the tool —
-connect with a MongoDB user that only has read permissions. That way the
-database itself rejects any write, as defense in depth.
+**Database scope.** The server operates on the database in your connection
+string. Aggregation stages that reach another database (`$out`, `$merge`,
+`$lookup` with an explicit `db`) are rejected by default, so a pipeline can't
+quietly read from or write to databases you didn't point it at. Enable them
+with `--allow-cross-db` if you need them.
+
+**Read-only mode** blocks every write path, including aggregation stages that
+write or run server-side JavaScript (`$out`, `$merge`, `$function`, `$where`,
+`$accumulator`).
+
+**Least privilege.** Application-level checks only go so far — the strongest
+guarantee comes from the database. Connect with a MongoDB user scoped to just
+the database you need, with read-only permissions when the assistant only needs
+to explore. That way the database itself enforces the boundary, as defense in
+depth.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-o
 | `--port`, `-p` | HTTP port (default `3001`) |
 | `--allowed-origins` | Comma-separated browser origins to allow in HTTP mode |
 | `--json-limit` | Max HTTP request body size (default `10mb`) |
+| `--auth-token` | Require `Authorization: Bearer <token>` on the HTTP endpoint |
 
 ### Environment Variables
 
@@ -95,6 +96,7 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-o
 | `MCP_PORT` | HTTP port |
 | `MCP_HTTP_ALLOWED_ORIGINS` | Comma-separated browser origins to allow in HTTP mode |
 | `MCP_HTTP_JSON_LIMIT` | Max HTTP request body size (default `10mb`) |
+| `MCP_HTTP_AUTH_TOKEN` | Bearer token required to access the HTTP endpoint |
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-o
 |------|-------------|
 | `--read-only`, `-r` | Block all write operations |
 | `--allow-cross-db` | Allow aggregation `$out`/`$merge`/`$lookup` to target other databases (off by default) |
+| `--allow-server-js` | Allow server-side JavaScript operators `$function`/`$where`/`$accumulator` (off by default) |
 | `--transport`, `-t` | `stdio` (default) or `http` |
 | `--port`, `-p` | HTTP port (default `3001`) |
 | `--allowed-origins` | Comma-separated browser origins to allow in HTTP mode |
@@ -90,6 +91,7 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 --allowed-o
 | `MCP_MONGODB_URI` | MongoDB connection URI (alternative to the argument) |
 | `MCP_MONGODB_READONLY` | Enable read-only mode (`"true"`) |
 | `MCP_MONGODB_ALLOW_CROSS_DB` | Allow cross-database aggregation stages (`"true"`) |
+| `MCP_MONGODB_ALLOW_SERVER_JS` | Allow server-side JavaScript operators (`"true"`) |
 | `MCP_PORT` | HTTP port |
 | `MCP_HTTP_ALLOWED_ORIGINS` | Comma-separated browser origins to allow in HTTP mode |
 | `MCP_HTTP_JSON_LIMIT` | Max HTTP request body size (default `10mb`) |
@@ -101,6 +103,11 @@ string. Aggregation stages that reach another database (`$out`, `$merge`,
 `$lookup` with an explicit `db`) are rejected by default, so a pipeline can't
 quietly read from or write to databases you didn't point it at. Enable them
 with `--allow-cross-db` if you need them.
+
+**Server-side JavaScript.** The aggregation operators `$function`, `$where`,
+and `$accumulator` run arbitrary JavaScript on the MongoDB server. They are
+rejected by default; enable them with `--allow-server-js` if you trust the
+pipelines being run.
 
 **Read-only mode** blocks every write path, including aggregation stages that
 write or run server-side JavaScript (`$out`, `$merge`, `$function`, `$where`,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Model Context Protocol (MCP) server that lets AI assistants work with your Mon
 - **Schema Inference** — automatic collection schema detection from document samples.
 - **Query & Aggregation** — full query and aggregation pipeline support, with optional `explain` plans.
 - **Write Operations** — insert, update, and index creation (when read-only mode is off).
+- **Time Conversion** — a `convertTime` helper turns Unix timestamps and date strings into UTC/GMT/ISO, so date queries stay unambiguous across timezones.
 - **Progress & Cancellation** — long operations report progress and can be cancelled mid-flight.
 - **Two Transports** — run locally over stdio, or expose an HTTP endpoint for remote access.
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,12 +4,14 @@
     "": {
       "name": "mcp-mongo-server",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/express": "^2.0.0-beta.5",
+        "@modelcontextprotocol/node": "^2.0.0-beta.5",
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
         "mongodb": "^7.5.0",
-        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.5",
+        "@modelcontextprotocol/client": "^2.0.0-beta.5",
         "@modelcontextprotocol/inspector": "^1.0.0",
         "@types/node": "^26.1.1",
         "tsup": "^8.5.1",
@@ -126,6 +128,12 @@
 
     "@mcp-ui/client": ["@mcp-ui/client@6.1.1", "", { "dependencies": { "@modelcontextprotocol/ext-apps": "^1.2.0", "@modelcontextprotocol/sdk": "^1.27.1", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-kN5io7ouEpVfOTloEEGrnuWio3ZzYOVgTk4o8ULleACdKEw7VgOTozPl9aj9qVl/UBh7rXlvKH0JbBm6Tw52LQ=="],
 
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0-beta.5", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0-beta.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0-beta.5", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew=="],
+
+    "@modelcontextprotocol/express": ["@modelcontextprotocol/express@2.0.0-beta.5", "", { "dependencies": { "cors": "^2.8.5" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0-beta.5", "express": "^4.18.0 || ^5.0.0" } }, "sha512-SDHAAKCOkHrxuBRyh6fRQJpjWBt5vrRCmvV7OIyWdmIksQzmTYsw7oEX1p9Kje6PSDqKJHpmqLJzZNUnOhrfCQ=="],
+
     "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ=="],
 
     "@modelcontextprotocol/inspector": ["@modelcontextprotocol/inspector@1.0.0", "", { "dependencies": { "@modelcontextprotocol/inspector-cli": "^1.0.0", "@modelcontextprotocol/inspector-client": "^1.0.0", "@modelcontextprotocol/inspector-server": "^1.0.0", "@modelcontextprotocol/sdk": "^1.25.2", "concurrently": "^9.2.0", "node-fetch": "^3.3.2", "open": "^10.2.0", "shell-quote": "^1.8.4", "spawn-rx": "^5.1.2", "ts-node": "^10.9.2", "zod": "^3.25.76" }, "bin": { "mcp-inspector": "cli/build/cli.js" } }, "sha512-QZ8LcTwE5+10MP8e5EYkY/u9za2plvfnl+mdKfG60yNg1K2xbIu2izmhG/6Jcnr0ncVsIKJtSPXeIkCngTDz6g=="],
@@ -136,7 +144,11 @@
 
     "@modelcontextprotocol/inspector-server": ["@modelcontextprotocol/inspector-server@1.0.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.25.2", "cors": "^2.8.5", "express": "^5.1.0", "express-rate-limit": "^8.2.1", "shell-quote": "^1.8.4", "shx": "^0.3.4", "spawn-rx": "^5.1.2", "ws": "^8.18.0", "zod": "^3.25.76" }, "bin": { "mcp-inspector-server": "build/index.js" } }, "sha512-XyqlwVp3mjewwetXwZ6x6dF2fFvO7L3CCNW3N6V3gUafw9YyQVt9TG1MacNO3rXfkhxna9SRRlV6pOalgk86sQ=="],
 
+    "@modelcontextprotocol/node": ["@modelcontextprotocol/node@2.0.0-beta.5", "", { "dependencies": { "@hono/node-server": "^1.19.9" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0-beta.5", "hono": "^4.11.4" }, "optionalPeers": ["hono"] }, "sha512-flrOzx5qFLBM9I8IYRGfYUY02erFmxOvYQ9sEE6iSj/ZZpRYKorXWscM/qrfW9rwlcGLyymHhnP2AaDbMB1lIA=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0-beta.5", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0-beta.5", "zod": "^4.2.0" } }, "sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.12", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA=="],
 
@@ -288,7 +300,7 @@
 
     "acorn-walk": ["acorn-walk@8.3.4", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g=="],
 
-    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
@@ -314,7 +326,7 @@
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+    "bytes": ["bytes@3.0.0", "", {}, "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -488,7 +500,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
@@ -746,13 +758,13 @@
 
     "@modelcontextprotocol/inspector/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@modelcontextprotocol/inspector-client/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
     "@modelcontextprotocol/inspector-client/pkce-challenge": ["pkce-challenge@4.1.0", "", {}, "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ=="],
 
     "@modelcontextprotocol/inspector-client/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@modelcontextprotocol/inspector-server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -770,6 +782,10 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "body-parser/bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "body-parser/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -784,6 +800,8 @@
 
     "is-core-module/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
+    "raw-body/bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "raw-body/http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "router/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
@@ -791,8 +809,6 @@
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "send/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
-
-    "serve-handler/bytes": ["bytes@3.0.0", "", {}, "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="],
 
     "serve-handler/content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
 
@@ -802,7 +818,9 @@
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
-    "@modelcontextprotocol/inspector-client/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "body-parser/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,14 +4,14 @@
     "": {
       "name": "mcp-mongo-server",
       "dependencies": {
-        "@modelcontextprotocol/express": "^2.0.0-beta.5",
-        "@modelcontextprotocol/node": "^2.0.0-beta.5",
-        "@modelcontextprotocol/server": "^2.0.0-beta.5",
+        "@modelcontextprotocol/express": "^2.0.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "mongodb": "^7.5.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.5",
-        "@modelcontextprotocol/client": "^2.0.0-beta.5",
+        "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/inspector": "^1.0.0",
         "@types/node": "^26.1.1",
         "tsup": "^8.5.1",
@@ -128,11 +128,11 @@
 
     "@mcp-ui/client": ["@mcp-ui/client@6.1.1", "", { "dependencies": { "@modelcontextprotocol/ext-apps": "^1.2.0", "@modelcontextprotocol/sdk": "^1.27.1", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-kN5io7ouEpVfOTloEEGrnuWio3ZzYOVgTk4o8ULleACdKEw7VgOTozPl9aj9qVl/UBh7rXlvKH0JbBm6Tw52LQ=="],
 
-    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0-beta.5", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0-beta.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
 
-    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0-beta.5", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew=="],
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
 
-    "@modelcontextprotocol/express": ["@modelcontextprotocol/express@2.0.0-beta.5", "", { "dependencies": { "cors": "^2.8.5" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0-beta.5", "express": "^4.18.0 || ^5.0.0" } }, "sha512-SDHAAKCOkHrxuBRyh6fRQJpjWBt5vrRCmvV7OIyWdmIksQzmTYsw7oEX1p9Kje6PSDqKJHpmqLJzZNUnOhrfCQ=="],
+    "@modelcontextprotocol/express": ["@modelcontextprotocol/express@2.0.0", "", { "dependencies": { "cors": "^2.8.5" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0", "express": "^4.18.0 || ^5.0.0" } }, "sha512-Snlr8j9FR9LcVvEJPF7qJ7d5zTL4Bes2dk7RcacN9eSZ7OLohwxqhEvWu1+UxELyScgLbLLOdeVEGdwKI1iwVQ=="],
 
     "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ=="],
 
@@ -144,11 +144,11 @@
 
     "@modelcontextprotocol/inspector-server": ["@modelcontextprotocol/inspector-server@1.0.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.25.2", "cors": "^2.8.5", "express": "^5.1.0", "express-rate-limit": "^8.2.1", "shell-quote": "^1.8.4", "shx": "^0.3.4", "spawn-rx": "^5.1.2", "ws": "^8.18.0", "zod": "^3.25.76" }, "bin": { "mcp-inspector-server": "build/index.js" } }, "sha512-XyqlwVp3mjewwetXwZ6x6dF2fFvO7L3CCNW3N6V3gUafw9YyQVt9TG1MacNO3rXfkhxna9SRRlV6pOalgk86sQ=="],
 
-    "@modelcontextprotocol/node": ["@modelcontextprotocol/node@2.0.0-beta.5", "", { "dependencies": { "@hono/node-server": "^1.19.9" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0-beta.5", "hono": "^4.11.4" }, "optionalPeers": ["hono"] }, "sha512-flrOzx5qFLBM9I8IYRGfYUY02erFmxOvYQ9sEE6iSj/ZZpRYKorXWscM/qrfW9rwlcGLyymHhnP2AaDbMB1lIA=="],
+    "@modelcontextprotocol/node": ["@modelcontextprotocol/node@2.0.0", "", { "dependencies": { "@hono/node-server": "^1.19.9" }, "peerDependencies": { "@modelcontextprotocol/server": "^2.0.0", "hono": "^4.11.4" }, "optionalPeers": ["hono"] }, "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0-beta.5", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0-beta.5", "zod": "^4.2.0" } }, "sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g=="],
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.12", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA=="],
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -51,6 +51,36 @@ HTTP request bodies are limited to `10mb` by default (matching the stdio
 transport). Raise or lower it with `--json-limit` (for example
 `--json-limit 50mb`) or the `MCP_HTTP_JSON_LIMIT` environment variable.
 
+### Requiring a token
+
+To require authentication, start the server with a bearer token:
+
+```bash
+MCP_HTTP_AUTH_TOKEN="your-secret-token" \
+  npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001
+```
+
+Every request must then send `Authorization: Bearer your-secret-token`;
+anything else gets a `401`. Point a client at it by adding the header to the
+server entry:
+
+```jsonc
+{
+  "mcpServers": {
+    "mongodb": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp",
+      "headers": { "Authorization": "Bearer your-secret-token" }
+    }
+  }
+}
+```
+
+Prefer the `MCP_HTTP_AUTH_TOKEN` environment variable over `--auth-token` so
+the token doesn't show up in the process list. This is a simple shared-secret
+check, not a full OAuth flow — for anything beyond a single trusted client,
+put the server behind a real authenticating proxy.
+
 ## Docker
 
 - [docker-compose example](../examples/docker-compose.yml)

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -21,6 +21,32 @@ Add the server configuration to Claude Desktop's config file:
 
 You can also use the environment variables approach with both Windsurf and Cursor, following the same pattern shown in the Claude Desktop configuration.
 
+## Remote access (HTTP)
+
+The examples above run the server locally over stdio. To reach it over the
+network instead — for a remote client or several clients at once — start it in
+HTTP mode:
+
+```bash
+npx -y mcp-mongo-server "mongodb://user:pass@localhost:27017/mydatabase" \
+  --transport http --port 3001
+```
+
+The server then listens for MCP requests at `http://<host>:3001/mcp`.
+
+For safety, browser requests are only accepted from `localhost` by default;
+any other browser `Origin` is rejected with `403` (DNS-rebinding protection).
+Non-browser clients (which send no `Origin` header) are always allowed. To let
+a specific web origin connect, list it explicitly:
+
+```bash
+npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 \
+  --allowed-origins "https://app.example.com"
+```
+
+The same value can be set with the `MCP_HTTP_ALLOWED_ORIGINS` environment
+variable (comma-separated for multiple origins).
+
 ## Docker
 
 - [docker-compose example](../examples/docker-compose.yml)

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -47,6 +47,10 @@ npx -y mcp-mongo-server "mongodb://..." --transport http --port 3001 \
 The same value can be set with the `MCP_HTTP_ALLOWED_ORIGINS` environment
 variable (comma-separated for multiple origins).
 
+HTTP request bodies are limited to `10mb` by default (matching the stdio
+transport). Raise or lower it with `--json-limit` (for example
+`--json-limit 50mb`) or the `MCP_HTTP_JSON_LIMIT` environment variable.
+
 ## Docker
 
 - [docker-compose example](../examples/docker-compose.yml)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -79,3 +79,20 @@
     includeDebugInfo: true  // Optional
   }
   ```
+
+## Utilities
+
+- **convertTime**: Convert a Unix timestamp or date string to UTC ISO 8601, GMT,
+  and Unix seconds/milliseconds, and report the server's current time and
+  timezone. Handy for building unambiguous date queries when the server and user
+  are in different timezones.
+  ```javascript
+  // Current server time (omit input)
+  {}
+
+  // From a Unix timestamp (seconds or milliseconds, auto-detected)
+  { input: 1735732800 }
+
+  // From a date string (with or without a timezone offset)
+  { input: "2025-06-15T08:30:00+03:00" }
+  ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-mongo-server",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "A Model Context Protocol server for MongoDB connections",
   "private": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "inspector": "mcp-inspector --config inspector-config.json --server mongodb"
   },
   "dependencies": {
-    "@modelcontextprotocol/express": "^2.0.0-beta.5",
-    "@modelcontextprotocol/node": "^2.0.0-beta.5",
-    "@modelcontextprotocol/server": "^2.0.0-beta.5",
+    "@modelcontextprotocol/express": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "mongodb": "^7.5.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",
-    "@modelcontextprotocol/client": "^2.0.0-beta.5",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/inspector": "^1.0.0",
     "@types/node": "^26.1.1",
     "tsup": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A Model Context Protocol server for MongoDB connections",
   "private": false,
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "mongodb": "./build/index.js"
   },
@@ -23,12 +26,14 @@
     "inspector": "mcp-inspector --config inspector-config.json --server mongodb"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "mongodb": "^7.5.0",
-    "zod": "^4.4.3"
+    "@modelcontextprotocol/express": "^2.0.0-beta.5",
+    "@modelcontextprotocol/node": "^2.0.0-beta.5",
+    "@modelcontextprotocol/server": "^2.0.0-beta.5",
+    "mongodb": "^7.5.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",
+    "@modelcontextprotocol/client": "^2.0.0-beta.5",
     "@modelcontextprotocol/inspector": "^1.0.0",
     "@types/node": "^26.1.1",
     "tsup": "^8.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { createMcpExpressApp } from "@modelcontextprotocol/express";
 import type { MongoClient } from "mongodb";
 import { connectToMongoDB } from "./mongo.js";
 import { createServer } from "./server.js";
@@ -117,9 +118,10 @@ async function startStdioServer(
   db: import("mongodb").Db,
   isReadOnlyMode: boolean,
 ) {
-  const server = createServer(client, db, isReadOnlyMode);
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  // serveStdio owns the era decision: a 2026-07-28 client opening is served the
+  // modern protocol, a 2025-era opening is served via the legacy shim — one
+  // factory, both eras.
+  serveStdio(() => createServer(client, db, isReadOnlyMode));
   console.warn("Server connected successfully via stdio");
 }
 
@@ -207,58 +209,17 @@ async function startHttpServer(
     next();
   });
 
-  app.post("/mcp", async (req, res) => {
-    const server = createServer(client, db, isReadOnlyMode);
-    try {
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-      res.on("close", () => {
-        transport.close();
-        server.close();
-      });
-    } catch (error) {
-      console.error("Error handling MCP request:", error);
-      if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32603,
-            message: "Internal server error",
-          },
-          id: null,
-        });
-      }
-    }
+  // Modern stateless MCP handler: one factory serves both the 2026-07-28 and
+  // legacy (2025-era) protocols per request. toNodeHandler adapts the
+  // fetch-shaped handler to Express, forwarding the body express.json() parsed.
+  const mcpHandler = createMcpHandler((_ctx) =>
+    createServer(client, db, isReadOnlyMode),
+  );
+  const nodeHandler = toNodeHandler(mcpHandler, {
+    onerror: (error) => console.error("Error handling MCP request:", error),
   });
 
-  app.get("/mcp", async (_req, res) => {
-    res.writeHead(405).end(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Method not allowed.",
-        },
-        id: null,
-      }),
-    );
-  });
-
-  app.delete("/mcp", async (_req, res) => {
-    res.writeHead(405).end(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Method not allowed.",
-        },
-        id: null,
-      }),
-    );
-  });
+  app.all("/mcp", (req, res) => nodeHandler(req, res, req.body));
 
   app.listen(port, () => {
     console.log(`MCP MongoDB Streamable HTTP Server listening on port ${port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ async function main() {
   let connectionUrl = "";
   let readOnlyMode = process.env.MCP_MONGODB_READONLY === "true" || false;
   let allowCrossDb = process.env.MCP_MONGODB_ALLOW_CROSS_DB === "true" || false;
+  let allowServerJs =
+    process.env.MCP_MONGODB_ALLOW_SERVER_JS === "true" || false;
   let transportMode: "stdio" | "http" = "stdio";
   let port = Number(process.env.MCP_PORT) || 3001;
   const allowedOrigins = (process.env.MCP_HTTP_ALLOWED_ORIGINS || "")
@@ -34,6 +36,8 @@ async function main() {
       readOnlyMode = true;
     } else if (args[i] === "--allow-cross-db") {
       allowCrossDb = true;
+    } else if (args[i] === "--allow-server-js") {
+      allowServerJs = true;
     } else if (args[i] === "--transport" || args[i] === "-t") {
       const value = args[++i];
       if (value !== "stdio" && value !== "http") {
@@ -111,12 +115,19 @@ async function main() {
         db,
         isReadOnlyMode,
         allowCrossDb,
+        allowServerJs,
         port,
         allowedOrigins,
         jsonLimit,
       );
     } else {
-      await startStdioServer(client, db, isReadOnlyMode, allowCrossDb);
+      await startStdioServer(
+        client,
+        db,
+        isReadOnlyMode,
+        allowCrossDb,
+        allowServerJs,
+      );
     }
   } catch (error) {
     console.error("Failed to connect to MongoDB:", error);
@@ -135,11 +146,14 @@ async function startStdioServer(
   db: import("mongodb").Db,
   isReadOnlyMode: boolean,
   allowCrossDb: boolean,
+  allowServerJs: boolean,
 ) {
   // serveStdio owns the era decision: a 2026-07-28 client opening is served the
   // modern protocol, a 2025-era opening is served via the legacy shim — one
   // factory, both eras.
-  serveStdio(() => createServer(client, db, isReadOnlyMode, allowCrossDb));
+  serveStdio(() =>
+    createServer(client, db, isReadOnlyMode, allowCrossDb, allowServerJs),
+  );
   console.warn("Server connected successfully via stdio");
 }
 
@@ -183,6 +197,7 @@ async function startHttpServer(
   db: import("mongodb").Db,
   isReadOnlyMode: boolean,
   allowCrossDb: boolean,
+  allowServerJs: boolean,
   port: number,
   allowedOrigins: string[],
   jsonLimit: string,
@@ -233,7 +248,7 @@ async function startHttpServer(
   // legacy (2025-era) protocols per request. toNodeHandler adapts the
   // fetch-shaped handler to Express, forwarding the body express.json() parsed.
   const mcpHandler = createMcpHandler((_ctx) =>
-    createServer(client, db, isReadOnlyMode, allowCrossDb),
+    createServer(client, db, isReadOnlyMode, allowCrossDb, allowServerJs),
   );
   const nodeHandler = toNodeHandler(mcpHandler, {
     onerror: (error) => console.error("Error handling MCP request:", error),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { toNodeHandler } from "@modelcontextprotocol/node";
 import { createMcpHandler } from "@modelcontextprotocol/server";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
@@ -29,6 +30,9 @@ async function main() {
   // Max HTTP request body size. Defaults to 10mb to match the stdio transport's
   // buffer, instead of Express's surprisingly low 100kb default.
   let jsonLimit = process.env.MCP_HTTP_JSON_LIMIT || "10mb";
+  // Optional static bearer token for the HTTP transport. When set, every
+  // request must carry `Authorization: Bearer <token>`. Empty = no auth.
+  let authToken = process.env.MCP_HTTP_AUTH_TOKEN || "";
 
   // Parse command line arguments (these take precedence)
   for (let i = 0; i < args.length; i++) {
@@ -61,6 +65,9 @@ async function main() {
     } else if (args[i] === "--json-limit") {
       const value = args[++i];
       if (value) jsonLimit = value;
+    } else if (args[i] === "--auth-token") {
+      const value = args[++i];
+      if (value) authToken = value;
     } else if (!connectionUrl) {
       connectionUrl = args[i];
     }
@@ -119,6 +126,7 @@ async function main() {
         port,
         allowedOrigins,
         jsonLimit,
+        authToken,
       );
     } else {
       await startStdioServer(
@@ -190,6 +198,25 @@ function isOriginAllowed(
 }
 
 /**
+ * Validate an `Authorization: Bearer <token>` header against the expected
+ * token using a constant-time comparison to avoid leaking it via timing.
+ */
+function bearerTokenValid(
+  authorization: string | undefined,
+  expected: string,
+): boolean {
+  const prefix = "Bearer ";
+  if (!authorization || !authorization.startsWith(prefix)) {
+    return false;
+  }
+  const provided = Buffer.from(authorization.slice(prefix.length));
+  const wanted = Buffer.from(expected);
+  return (
+    provided.length === wanted.length && timingSafeEqual(provided, wanted)
+  );
+}
+
+/**
  * Start the server with Streamable HTTP transport.
  */
 async function startHttpServer(
@@ -201,6 +228,7 @@ async function startHttpServer(
   port: number,
   allowedOrigins: string[],
   jsonLimit: string,
+  authToken: string,
 ) {
   const app = createMcpExpressApp({ host: "0.0.0.0", jsonLimit });
 
@@ -243,6 +271,29 @@ async function startHttpServer(
     }
     next();
   });
+
+  // Optional bearer-token auth: when a token is configured, every request must
+  // present it. Invalid or missing tokens get a 401 with a Bearer challenge, as
+  // required by the MCP authorization spec (RFC 6750 / OAuth 2.1 Section 5.3).
+  if (authToken) {
+    app.use((req, res, next) => {
+      if (!bearerTokenValid(req.headers.authorization, authToken)) {
+        res
+          .status(401)
+          .set("WWW-Authenticate", 'Bearer realm="mcp", error="invalid_token"')
+          .json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32001,
+              message: "Unauthorized: missing or invalid bearer token",
+            },
+            id: null,
+          });
+        return;
+      }
+      next();
+    });
+  }
 
   // Modern stateless MCP handler: one factory serves both the 2026-07-28 and
   // legacy (2025-era) protocols per request. toNodeHandler adapts the

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ function bearerTokenValid(
   expected: string,
 ): boolean {
   const prefix = "Bearer ";
-  if (!authorization || !authorization.startsWith(prefix)) {
+  if (!authorization?.startsWith(prefix)) {
     return false;
   }
   const provided = Buffer.from(authorization.slice(prefix.length));

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,9 @@ async function main() {
     .split(",")
     .map((origin) => origin.trim())
     .filter(Boolean);
+  // Max HTTP request body size. Defaults to 10mb to match the stdio transport's
+  // buffer, instead of Express's surprisingly low 100kb default.
+  let jsonLimit = process.env.MCP_HTTP_JSON_LIMIT || "10mb";
 
   // Parse command line arguments (these take precedence)
   for (let i = 0; i < args.length; i++) {
@@ -48,6 +51,9 @@ async function main() {
           .map((origin) => origin.trim())
           .filter(Boolean),
       );
+    } else if (args[i] === "--json-limit") {
+      const value = args[++i];
+      if (value) jsonLimit = value;
     } else if (!connectionUrl) {
       connectionUrl = args[i];
     }
@@ -97,7 +103,14 @@ async function main() {
     }
 
     if (transportMode === "http") {
-      await startHttpServer(client, db, isReadOnlyMode, port, allowedOrigins);
+      await startHttpServer(
+        client,
+        db,
+        isReadOnlyMode,
+        port,
+        allowedOrigins,
+        jsonLimit,
+      );
     } else {
       await startStdioServer(client, db, isReadOnlyMode);
     }
@@ -166,8 +179,9 @@ async function startHttpServer(
   isReadOnlyMode: boolean,
   port: number,
   allowedOrigins: string[],
+  jsonLimit: string,
 ) {
-  const app = createMcpExpressApp({ host: "0.0.0.0" });
+  const app = createMcpExpressApp({ host: "0.0.0.0", jsonLimit });
 
   // Request logging middleware
   app.use((req, res, next) => {
@@ -220,6 +234,34 @@ async function startHttpServer(
   });
 
   app.all("/mcp", (req, res) => nodeHandler(req, res, req.body));
+
+  // Turn body-parser failures (payload too large, malformed JSON) into
+  // JSON-RPC errors instead of Express's default HTML error page.
+  app.use(
+    (
+      err: { type?: string; status?: number; statusCode?: number; message?: string },
+      _req: unknown,
+      res: {
+        headersSent: boolean;
+        status: (code: number) => { json: (body: unknown) => void };
+      },
+      next: (err?: unknown) => void,
+    ) => {
+      if (res.headersSent) return next(err);
+      const status = err.status ?? err.statusCode ?? 400;
+      const tooLarge = err.type === "entity.too.large" || status === 413;
+      res.status(tooLarge ? 413 : 400).json({
+        jsonrpc: "2.0",
+        error: {
+          code: tooLarge ? -32600 : -32700,
+          message: tooLarge
+            ? "Request body exceeds the configured size limit"
+            : `Invalid request body: ${err.message ?? "parse error"}`,
+        },
+        id: null,
+      });
+    },
+  );
 
   app.listen(port, () => {
     console.log(`MCP MongoDB Streamable HTTP Server listening on port ${port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ async function main() {
   // Default to environment variables
   let connectionUrl = "";
   let readOnlyMode = process.env.MCP_MONGODB_READONLY === "true" || false;
+  let allowCrossDb = process.env.MCP_MONGODB_ALLOW_CROSS_DB === "true" || false;
   let transportMode: "stdio" | "http" = "stdio";
   let port = Number(process.env.MCP_PORT) || 3001;
   const allowedOrigins = (process.env.MCP_HTTP_ALLOWED_ORIGINS || "")
@@ -31,6 +32,8 @@ async function main() {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--read-only" || args[i] === "-r") {
       readOnlyMode = true;
+    } else if (args[i] === "--allow-cross-db") {
+      allowCrossDb = true;
     } else if (args[i] === "--transport" || args[i] === "-t") {
       const value = args[++i];
       if (value !== "stdio" && value !== "http") {
@@ -107,12 +110,13 @@ async function main() {
         client,
         db,
         isReadOnlyMode,
+        allowCrossDb,
         port,
         allowedOrigins,
         jsonLimit,
       );
     } else {
-      await startStdioServer(client, db, isReadOnlyMode);
+      await startStdioServer(client, db, isReadOnlyMode, allowCrossDb);
     }
   } catch (error) {
     console.error("Failed to connect to MongoDB:", error);
@@ -130,11 +134,12 @@ async function startStdioServer(
   client: MongoClient,
   db: import("mongodb").Db,
   isReadOnlyMode: boolean,
+  allowCrossDb: boolean,
 ) {
   // serveStdio owns the era decision: a 2026-07-28 client opening is served the
   // modern protocol, a 2025-era opening is served via the legacy shim — one
   // factory, both eras.
-  serveStdio(() => createServer(client, db, isReadOnlyMode));
+  serveStdio(() => createServer(client, db, isReadOnlyMode, allowCrossDb));
   console.warn("Server connected successfully via stdio");
 }
 
@@ -177,6 +182,7 @@ async function startHttpServer(
   client: MongoClient,
   db: import("mongodb").Db,
   isReadOnlyMode: boolean,
+  allowCrossDb: boolean,
   port: number,
   allowedOrigins: string[],
   jsonLimit: string,
@@ -227,7 +233,7 @@ async function startHttpServer(
   // legacy (2025-era) protocols per request. toNodeHandler adapts the
   // fetch-shaped handler to Express, forwarding the body express.json() parsed.
   const mcpHandler = createMcpHandler((_ctx) =>
-    createServer(client, db, isReadOnlyMode),
+    createServer(client, db, isReadOnlyMode, allowCrossDb),
   );
   const nodeHandler = toNodeHandler(mcpHandler, {
     onerror: (error) => console.error("Error handling MCP request:", error),

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -86,11 +86,23 @@ const READONLY_FORBIDDEN_AGG_OPERATORS = new Set([
 /**
  * Recursively scan an aggregation pipeline for any operator in `operators`
  * (matched case-sensitively as object keys). Returns the first match, or null.
+ * Guards against overly deep nesting so a pathological pipeline can't overflow
+ * the stack before the operator/depth checks run.
  */
-function findAggOperator(value: unknown, operators: Set<string>): string | null {
+function findAggOperator(
+  value: unknown,
+  operators: Set<string>,
+  depth = 0,
+): string | null {
+  if (depth > MAX_OBJECT_DEPTH) {
+    throw new Error(
+      `Object nesting exceeds the maximum depth of ${MAX_OBJECT_DEPTH}`,
+    );
+  }
+
   if (Array.isArray(value)) {
     for (const item of value) {
-      const found = findAggOperator(item, operators);
+      const found = findAggOperator(item, operators, depth + 1);
       if (found) return found;
     }
     return null;
@@ -101,7 +113,7 @@ function findAggOperator(value: unknown, operators: Set<string>): string | null 
       if (operators.has(key)) {
         return key;
       }
-      const found = findAggOperator(nested, operators);
+      const found = findAggOperator(nested, operators, depth + 1);
       if (found) return found;
     }
   }

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -104,6 +104,44 @@ function findForbiddenAggOperator(value: unknown): string | null {
   return null;
 }
 
+/**
+ * Scan an aggregation pipeline for stages that read from or write to a database
+ * other than the connected one ($out, $merge, $lookup with an explicit `db`).
+ * Returns the first foreign database name found, or null. Used to keep the
+ * server scoped to its connected database unless cross-database access is
+ * explicitly enabled.
+ */
+function findCrossDbTarget(
+  pipeline: unknown[],
+  connectedDb: string,
+): string | null {
+  const foreignDb = (target: unknown): string | null => {
+    if (target && typeof target === "object" && "db" in target) {
+      const db = (target as { db?: unknown }).db;
+      if (typeof db === "string" && db && db !== connectedDb) return db;
+    }
+    return null;
+  };
+
+  for (const stage of pipeline) {
+    if (!stage || typeof stage !== "object") continue;
+    const s = stage as Record<string, unknown>;
+    // $out: "<db>.<coll>" is same-db; { db, coll } may target another db
+    const out = foreignDb(s.$out);
+    if (out) return out;
+    // $merge: { into: "<coll>" | { db, coll } }
+    const merge = s.$merge as { into?: unknown } | undefined;
+    const mergeInto = foreignDb(merge?.into ?? s.$merge);
+    if (mergeInto) return mergeInto;
+    // $lookup: { from: { db, coll } } (cross-db read)
+    const lookup = s.$lookup as { from?: unknown } | undefined;
+    const lookupFrom = foreignDb(lookup?.from);
+    if (lookupFrom) return lookupFrom;
+  }
+
+  return null;
+}
+
 // ObjectId conversion settings
 type ObjectIdConversionMode = "auto" | "none" | "force";
 
@@ -112,12 +150,14 @@ export async function handleCallToolRequest({
   client,
   db,
   isReadOnlyMode,
+  allowCrossDb = false,
   signal,
 }: {
   request: CallToolRequest;
   client: MongoClient;
   db: Db;
   isReadOnlyMode: boolean;
+  allowCrossDb?: boolean;
   signal?: AbortSignal;
 }) {
   const { name, arguments: args = {} } = request.params;
@@ -176,6 +216,7 @@ export async function handleCallToolRequest({
       collection,
       db,
       isReadOnlyMode,
+      allowCrossDb,
       args,
       objectIdMode,
       signal,
@@ -196,6 +237,7 @@ async function executeOperation(
   collection: Collection<Document> | null,
   db: Db,
   isReadOnlyMode: boolean,
+  allowCrossDb: boolean,
   args: Record<string, unknown>,
   objectIdMode: ObjectIdConversionMode,
   signal?: AbortSignal,
@@ -209,6 +251,7 @@ async function executeOperation(
         args,
         objectIdMode,
         isReadOnlyMode,
+        allowCrossDb,
         signal,
       );
     case "update":
@@ -565,6 +608,7 @@ async function handleAggregate(
   args: Record<string, unknown>,
   objectIdMode: ObjectIdConversionMode = "auto",
   isReadOnlyMode = false,
+  allowCrossDb = false,
   signal?: AbortSignal,
 ) {
   if (!collection) {
@@ -584,6 +628,17 @@ async function handleAggregate(
     if (forbidden) {
       throw new Error(
         `ReadonlyError: Aggregation operator '${forbidden}' is not allowed in read-only mode`,
+      );
+    }
+  }
+
+  // Keep the server scoped to its connected database: reject $out/$merge/$lookup
+  // that target another database, unless cross-database access is enabled.
+  if (!allowCrossDb) {
+    const foreignDb = findCrossDbTarget(pipeline, collection.dbName);
+    if (foreignDb) {
+      throw new Error(
+        `Cross-database access to '${foreignDb}' is not allowed (connected database is '${collection.dbName}'). Enable it with --allow-cross-db or MCP_MONGODB_ALLOW_CROSS_DB=true.`,
       );
     }
   }

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -1,10 +1,8 @@
-import type { CreateTaskResult } from "@modelcontextprotocol/sdk/experimental/tasks";
-import type { RequestTaskStore } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import {
-  type CallToolRequest,
-  ErrorCode,
-  McpError,
-} from "@modelcontextprotocol/sdk/types.js";
+import { ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
+import type {
+  CallToolRequest,
+  CallToolResult,
+} from "@modelcontextprotocol/server";
 import type {
   BulkWriteOptions,
   CollationOptions,
@@ -109,16 +107,12 @@ export async function handleCallToolRequest({
   db,
   isReadOnlyMode,
   signal,
-  taskStore,
-  taskTtl,
 }: {
   request: CallToolRequest;
   client: MongoClient;
   db: Db;
   isReadOnlyMode: boolean;
   signal?: AbortSignal;
-  taskStore?: RequestTaskStore;
-  taskTtl?: number | null;
 }) {
   const { name, arguments: args = {} } = request.params;
   const operation = name as MongoOperation;
@@ -171,43 +165,6 @@ export async function handleCallToolRequest({
 
     signal?.throwIfAborted();
 
-    // Task-augmented request: create task, run async, return immediately
-    if (taskStore) {
-      const task = await taskStore.createTask({
-        ttl: taskTtl ?? undefined,
-      });
-
-      // Fire-and-forget: run the operation in the background
-      (async () => {
-        try {
-          const result = await executeOperation(
-            operation,
-            collection,
-            db,
-            isReadOnlyMode,
-            args,
-            objectIdMode,
-            signal,
-          );
-          await taskStore.storeTaskResult(task.taskId, "completed", result);
-        } catch (error) {
-          try {
-            const message =
-              error instanceof Error ? error.message : "Unknown error";
-            await taskStore.storeTaskResult(task.taskId, "failed", {
-              content: [{ type: "text", text: message }],
-              isError: true,
-            });
-          } catch {
-            // Task may already be in a terminal state (cancelled, completed, or failed)
-          }
-        }
-      })();
-
-      return { task } as CreateTaskResult;
-    }
-
-    // Synchronous execution path
     return await executeOperation(
       operation,
       collection,
@@ -219,7 +176,7 @@ export async function handleCallToolRequest({
     );
   } catch (error) {
     // Protocol-level errors and cancellation propagate unchanged
-    if (error instanceof McpError || signal?.aborted) {
+    if (error instanceof ProtocolError || signal?.aborted) {
       throw error;
     }
     return toolExecutionError(
@@ -261,7 +218,7 @@ async function executeOperation(
     case "listCollections":
       return handleListCollections(db, args, objectIdMode, signal);
     default:
-      throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${operation}`);
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${operation}`);
   }
 }
 
@@ -280,7 +237,7 @@ function validateOperation(operation: MongoOperation): void {
   ];
 
   if (!validOperations.includes(operation)) {
-    throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${operation}`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${operation}`);
   }
 }
 
@@ -496,9 +453,7 @@ function isISODateString(str: string): boolean {
   return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(str);
 }
 
-function formatResponse(data: unknown): {
-  content: [{ type: string; text: string }];
-} {
+function formatResponse(data: unknown): CallToolResult {
   return {
     content: [
       {
@@ -509,10 +464,7 @@ function formatResponse(data: unknown): {
   };
 }
 
-function toolExecutionError(message: string): {
-  content: [{ type: string; text: string }];
-  isError: true;
-} {
+function toolExecutionError(message: string): CallToolResult {
   return {
     content: [{ type: "text", text: message }],
     isError: true,

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -20,13 +20,6 @@ import type {
 import { ObjectId } from "mongodb";
 
 // MongoDB return type interfaces
-interface CreateIndexesResult {
-  acknowledged: boolean;
-  createdIndexes: string[];
-  numIndexesBefore: number;
-  numIndexesAfter: number;
-}
-
 interface BulkWriteError extends Error {
   name: string;
   writeErrors?: Array<unknown>;
@@ -991,19 +984,16 @@ async function handleCreateIndex(
     };
 
     signal?.throwIfAborted();
-    const result = await collection.createIndexes(
+    // The driver's createIndexes resolves to the list of created index names.
+    const createdIndexes = await collection.createIndexes(
       processedIndexes,
       indexOptions,
     );
 
-    // Type assertion for createIndexes result
     return formatResponse({
-      acknowledged: (result as unknown as CreateIndexesResult).acknowledged,
-      createdIndexes: (result as unknown as CreateIndexesResult).createdIndexes,
-      numIndexesBefore: (result as unknown as CreateIndexesResult)
-        .numIndexesBefore,
-      numIndexesAfter: (result as unknown as CreateIndexesResult)
-        .numIndexesAfter,
+      acknowledged: true,
+      createdIndexes,
+      indexCount: createdIndexes.length,
     });
   } catch (error) {
     return handleError(error, "create indexes", collection.collectionName);

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -66,26 +66,31 @@ const WRITE_OPERATIONS = ["update", "insert", "createIndex"];
 // overflow on pathologically deep input.
 const MAX_OBJECT_DEPTH = 100;
 
-// Aggregation stages/operators that must never run in read-only mode:
-// write stages ($out, $merge) can create or replace collections, and
-// server-side JavaScript operators ($function, $accumulator, $where) allow
-// arbitrary code execution. All are matched case-sensitively as object keys.
-const READONLY_FORBIDDEN_AGG_OPERATORS = new Set([
-  "$out",
-  "$merge",
+// Aggregation write stages ($out, $merge) can create or replace collections.
+const WRITE_AGG_STAGES = new Set(["$out", "$merge"]);
+
+// Server-side JavaScript operators allow arbitrary code execution on the
+// MongoDB server (and are a denial-of-service vector via infinite loops).
+const SERVER_JS_AGG_OPERATORS = new Set([
   "$function",
   "$accumulator",
   "$where",
 ]);
 
+// Everything blocked in read-only mode: no writes and no server-side JS.
+const READONLY_FORBIDDEN_AGG_OPERATORS = new Set([
+  ...WRITE_AGG_STAGES,
+  ...SERVER_JS_AGG_OPERATORS,
+]);
+
 /**
- * Recursively scan an aggregation pipeline for operators that are forbidden in
- * read-only mode. Returns the first forbidden operator found, or null.
+ * Recursively scan an aggregation pipeline for any operator in `operators`
+ * (matched case-sensitively as object keys). Returns the first match, or null.
  */
-function findForbiddenAggOperator(value: unknown): string | null {
+function findAggOperator(value: unknown, operators: Set<string>): string | null {
   if (Array.isArray(value)) {
     for (const item of value) {
-      const found = findForbiddenAggOperator(item);
+      const found = findAggOperator(item, operators);
       if (found) return found;
     }
     return null;
@@ -93,10 +98,10 @@ function findForbiddenAggOperator(value: unknown): string | null {
 
   if (value && typeof value === "object") {
     for (const [key, nested] of Object.entries(value)) {
-      if (READONLY_FORBIDDEN_AGG_OPERATORS.has(key)) {
+      if (operators.has(key)) {
         return key;
       }
-      const found = findForbiddenAggOperator(nested);
+      const found = findAggOperator(nested, operators);
       if (found) return found;
     }
   }
@@ -151,6 +156,7 @@ export async function handleCallToolRequest({
   db,
   isReadOnlyMode,
   allowCrossDb = false,
+  allowServerJs = false,
   signal,
 }: {
   request: CallToolRequest;
@@ -158,6 +164,7 @@ export async function handleCallToolRequest({
   db: Db;
   isReadOnlyMode: boolean;
   allowCrossDb?: boolean;
+  allowServerJs?: boolean;
   signal?: AbortSignal;
 }) {
   const { name, arguments: args = {} } = request.params;
@@ -217,6 +224,7 @@ export async function handleCallToolRequest({
       db,
       isReadOnlyMode,
       allowCrossDb,
+      allowServerJs,
       args,
       objectIdMode,
       signal,
@@ -238,6 +246,7 @@ async function executeOperation(
   db: Db,
   isReadOnlyMode: boolean,
   allowCrossDb: boolean,
+  allowServerJs: boolean,
   args: Record<string, unknown>,
   objectIdMode: ObjectIdConversionMode,
   signal?: AbortSignal,
@@ -252,6 +261,7 @@ async function executeOperation(
         objectIdMode,
         isReadOnlyMode,
         allowCrossDb,
+        allowServerJs,
         signal,
       );
     case "update":
@@ -294,7 +304,8 @@ function validateCollection(collection: Collection<Document>): void {
   if (!collection.collectionName) {
     throw new Error("Collection name cannot be empty");
   }
-  if (collection.collectionName.startsWith("system.")) {
+  // Case-insensitive so 'System.' and other casings can't slip past the guard.
+  if (collection.collectionName.toLowerCase().startsWith("system.")) {
     throw new Error("Access to system collections is not allowed");
   }
 }
@@ -609,6 +620,7 @@ async function handleAggregate(
   objectIdMode: ObjectIdConversionMode = "auto",
   isReadOnlyMode = false,
   allowCrossDb = false,
+  allowServerJs = false,
   signal?: AbortSignal,
 ) {
   if (!collection) {
@@ -624,10 +636,25 @@ async function handleAggregate(
   // execute server-side JavaScript. Without this an aggregate ending in $out
   // or $merge would bypass read-only protection and overwrite collections.
   if (isReadOnlyMode) {
-    const forbidden = findForbiddenAggOperator(pipeline);
+    const forbidden = findAggOperator(
+      pipeline,
+      READONLY_FORBIDDEN_AGG_OPERATORS,
+    );
     if (forbidden) {
       throw new Error(
         `ReadonlyError: Aggregation operator '${forbidden}' is not allowed in read-only mode`,
+      );
+    }
+  }
+
+  // Server-side JavaScript ($function/$where/$accumulator) is arbitrary code
+  // execution on the MongoDB server; reject it by default even outside
+  // read-only mode, unless explicitly enabled.
+  if (!allowServerJs) {
+    const js = findAggOperator(pipeline, SERVER_JS_AGG_OPERATORS);
+    if (js) {
+      throw new Error(
+        `Server-side JavaScript operator '${js}' is not allowed. Enable it with --allow-server-js or MCP_MONGODB_ALLOW_SERVER_JS=true.`,
       );
     }
   }

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -45,7 +45,8 @@ type MongoOperation =
   | "insert"
   | "createIndex"
   | "count"
-  | "listCollections";
+  | "listCollections"
+  | "convertTime";
 
 // Define operations that require a collection
 const COLLECTION_OPERATIONS = [
@@ -288,6 +289,8 @@ async function executeOperation(
       return handleCount(collection, args, objectIdMode, signal);
     case "listCollections":
       return handleListCollections(db, args, objectIdMode, signal);
+    case "convertTime":
+      return handleConvertTime(args);
     default:
       throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${operation}`);
   }
@@ -305,6 +308,7 @@ function validateOperation(operation: MongoOperation): void {
     "createIndex",
     "count",
     "listCollections",
+    "convertTime",
   ];
 
   if (!validOperations.includes(operation)) {
@@ -528,10 +532,14 @@ function isObjectIdString(str: string): boolean {
   return /^[0-9a-fA-F]{24}$/.test(str);
 }
 
-// Helper function to check if a string is in ISO date format
+// Helper function to check if a string is an unambiguous ISO 8601 timestamp.
+// Requires an explicit timezone — either 'Z' (UTC) or a numeric offset like
+// '+03:00' — so a value always maps to one instant regardless of the server's
+// timezone. Timezone-less strings are intentionally left as plain strings.
 function isISODateString(str: string): boolean {
-  // Check if string matches ISO 8601 format
-  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(str);
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?(Z|[+-]\d{2}:\d{2})$/.test(
+    str,
+  );
 }
 
 function formatResponse(data: unknown): CallToolResult {
@@ -1052,6 +1060,59 @@ async function handleCount(
   } catch (error) {
     return handleError(error, "count documents", collection.collectionName);
   }
+}
+
+function handleConvertTime(args: Record<string, unknown>): CallToolResult {
+  const { input } = args;
+  let date: Date;
+
+  if (input === undefined || input === null || input === "") {
+    // No input: report the current time.
+    date = new Date();
+  } else if (typeof input === "number") {
+    // Auto-detect seconds vs milliseconds: values below ~1e12 (year 2001 in
+    // milliseconds) are treated as seconds, everything else as milliseconds.
+    date = new Date(Math.abs(input) < 1e12 ? input * 1000 : input);
+  } else if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (/^-?\d+$/.test(trimmed)) {
+      const n = Number(trimmed);
+      date = new Date(Math.abs(n) < 1e12 ? n * 1000 : n);
+    } else {
+      // Any date string the JS engine understands (ISO 8601, with or without
+      // an offset, RFC 2822, etc.).
+      date = new Date(trimmed);
+    }
+  } else {
+    throw new Error(
+      "convertTime 'input' must be a Unix timestamp (number) or a date string",
+    );
+  }
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `Could not interpret '${String(input)}' as a date or Unix timestamp`,
+    );
+  }
+
+  // Server timezone offset (in ±HH:MM), respecting DST for the given date.
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absMinutes = Math.abs(offsetMinutes);
+  const offsetLabel = `${sign}${String(Math.floor(absMinutes / 60)).padStart(
+    2,
+    "0",
+  )}:${String(absMinutes % 60).padStart(2, "0")}`;
+
+  return formatResponse({
+    iso: date.toISOString(),
+    utc: date.toUTCString(),
+    unixSeconds: Math.floor(date.getTime() / 1000),
+    unixMillis: date.getTime(),
+    serverLocal: date.toString(),
+    serverTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    serverUtcOffset: offsetLabel,
+  });
 }
 
 async function handleListCollections(

--- a/src/schemas/call.ts
+++ b/src/schemas/call.ts
@@ -60,6 +60,12 @@ const COLLECTION_OPERATIONS = [
 // Define write operations that are blocked in read-only mode
 const WRITE_OPERATIONS = ["update", "insert", "createIndex"];
 
+// Maximum object nesting depth we will walk when converting ObjectId/date
+// strings. Matches MongoDB's own BSON nesting limit, so we reject the same
+// inputs it would — but with a clear error and without risking a stack
+// overflow on pathologically deep input.
+const MAX_OBJECT_DEPTH = 100;
+
 // Aggregation stages/operators that must never run in read-only mode:
 // write stages ($out, $merge) can create or replace collections, and
 // server-side JavaScript operators ($function, $accumulator, $where) allow
@@ -321,7 +327,14 @@ function isObjectIdField(fieldName: string): boolean {
 function processObjectIdInFilter(
   filter: Record<string, unknown>,
   objectIdMode: ObjectIdConversionMode = "auto",
+  depth = 0,
 ): Filter<Document> {
+  if (depth > MAX_OBJECT_DEPTH) {
+    throw new Error(
+      `Object nesting exceeds the maximum depth of ${MAX_OBJECT_DEPTH}`,
+    );
+  }
+
   // If objectIdMode is "none", don't convert any strings to ObjectIds
   if (objectIdMode === "none") {
     // Create a new filter object to handle dates
@@ -364,6 +377,7 @@ function processObjectIdInFilter(
           result[key] = processObjectIdInFilter(
             value as Record<string, unknown>,
             "none",
+            depth + 1,
           );
         }
       } else {
@@ -431,6 +445,7 @@ function processObjectIdInFilter(
         result[key] = processObjectIdInFilter(
           value as Record<string, unknown>,
           objectIdMode,
+          depth + 1,
         );
       }
     } else {

--- a/src/schemas/completion.ts
+++ b/src/schemas/completion.ts
@@ -1,7 +1,4 @@
-import type {
-  CompleteRequest,
-  CompleteResult,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { CompleteRequest, CompleteResult } from "@modelcontextprotocol/server";
 import type { CollectionInfo, Db, MongoClient } from "mongodb";
 import { paginate } from "../utils/pagination.js";
 

--- a/src/schemas/ping.ts
+++ b/src/schemas/ping.ts
@@ -1,4 +1,4 @@
-import type { PingRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { PingRequest } from "@modelcontextprotocol/server";
 import type { Db, MongoClient } from "mongodb";
 
 export async function handlePingRequest({

--- a/src/schemas/prompts.ts
+++ b/src/schemas/prompts.ts
@@ -1,7 +1,8 @@
 import type {
   GetPromptRequest,
+  GetPromptResult,
   ListPromptsRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+} from "@modelcontextprotocol/server";
 import type { Db, MongoClient } from "mongodb";
 import type { SendProgressFn } from "../server.js";
 
@@ -49,7 +50,7 @@ export async function handleGetPromptRequest({
   isReadOnlyMode: boolean;
   signal?: AbortSignal;
   sendProgress?: SendProgressFn;
-}) {
+}): Promise<GetPromptResult> {
   const { name, arguments: args = {} } = request.params;
 
   if (name !== "analyze_collection") {

--- a/src/schemas/resource.ts
+++ b/src/schemas/resource.ts
@@ -1,7 +1,9 @@
-import type {
-  ListResourcesRequest,
-  ReadResourceRequest,
-} from "@modelcontextprotocol/sdk/types.js";
+import {
+  type ListResourcesRequest,
+  ProtocolError,
+  ProtocolErrorCode,
+  type ReadResourceRequest,
+} from "@modelcontextprotocol/server";
 import type {
   CollectionInfo,
   Db,
@@ -205,8 +207,39 @@ export async function handleReadResourceRequest({
   signal?: AbortSignal;
   sendProgress?: SendProgressFn;
 }) {
-  const url = new URL(request.params.uri);
-  const collectionName = url.pathname.replace(/^\//, "");
+  // Validate the resource URI. A malformed URI or a missing/invalid collection
+  // name is a bad request: per the 2026-07-28 spec, resources/read misses use
+  // InvalidParams (-32602) rather than the legacy -32002 (SEP-2164).
+  let collectionName: string;
+  try {
+    const url = new URL(request.params.uri);
+    if (url.protocol !== "mongodb:") {
+      throw new ProtocolError(
+        ProtocolErrorCode.InvalidParams,
+        `Unsupported resource URI scheme '${url.protocol}': expected 'mongodb:'`,
+      );
+    }
+    collectionName = url.pathname.replace(/^\//, "");
+  } catch (error) {
+    if (error instanceof ProtocolError) throw error;
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Invalid resource URI: ${request.params.uri}`,
+    );
+  }
+
+  if (!collectionName) {
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      "Resource URI is missing a collection name",
+    );
+  }
+  if (collectionName.startsWith("system.")) {
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      "Access to system collections is not allowed",
+    );
+  }
 
   try {
     const collection = db.collection(collectionName);

--- a/src/schemas/templates.ts
+++ b/src/schemas/templates.ts
@@ -1,4 +1,4 @@
-import type { ListResourceTemplatesRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { ListResourceTemplatesRequest } from "@modelcontextprotocol/server";
 import type { Db, MongoClient } from "mongodb";
 
 export async function handleListResourceTemplatesRequest({

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -322,6 +322,21 @@ export async function handleListToolsRequest({
           },
         },
       },
+      {
+        name: "convertTime",
+        description:
+          "Convert a Unix timestamp or date string to multiple formats (UTC ISO 8601, GMT, Unix seconds/milliseconds) and report the server's current time and timezone. Useful for building unambiguous date queries when the server and user are in different timezones. Omit 'input' to get the current time.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            input: {
+              type: "string",
+              description:
+                "A Unix timestamp (seconds or milliseconds, as a number or numeric string) or a date string (ISO 8601, with or without a timezone offset). Omit to use the current server time.",
+            },
+          },
+        },
+      },
     ],
   };
 }

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -50,6 +50,11 @@ export async function handleListToolsRequest({
                 "Number of documents to skip before returning results",
               default: 0,
             },
+            sort: {
+              type: "object",
+              description:
+                "Sort order as a field-to-direction map, e.g. { orderDate: -1 } for descending or { name: 1 } for ascending",
+            },
             explain: {
               type: "string",
               description: "Optional: Get query execution information",

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -1,4 +1,7 @@
-import type { ListToolsRequest } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  ListToolsRequest,
+  ListToolsResult,
+} from "@modelcontextprotocol/server";
 import type { Db, MongoClient } from "mongodb";
 
 export async function handleListToolsRequest({
@@ -13,14 +16,13 @@ export async function handleListToolsRequest({
   db: Db;
   isReadOnlyMode: boolean;
   signal?: AbortSignal;
-}) {
+}): Promise<ListToolsResult> {
   return {
     tools: [
       {
         name: "query",
         description:
           "Execute a MongoDB query with optional execution plan analysis",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -67,7 +69,6 @@ export async function handleListToolsRequest({
         name: "aggregate",
         description:
           "Execute a MongoDB aggregation pipeline with optional execution plan analysis",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -102,7 +103,6 @@ export async function handleListToolsRequest({
       {
         name: "update",
         description: "Update documents in a MongoDB collection",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -143,7 +143,6 @@ export async function handleListToolsRequest({
         name: "serverInfo",
         description:
           "Get MongoDB server information including version, storage engine, and other details",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -158,7 +157,6 @@ export async function handleListToolsRequest({
       {
         name: "insert",
         description: "Insert one or more documents into a MongoDB collection",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -197,7 +195,6 @@ export async function handleListToolsRequest({
       {
         name: "createIndex",
         description: "Create one or more indexes on a MongoDB collection",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -264,7 +261,6 @@ export async function handleListToolsRequest({
       {
         name: "count",
         description: "Count documents in a collection matching a query",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {
@@ -295,7 +291,6 @@ export async function handleListToolsRequest({
       {
         name: "listCollections",
         description: "List all collections in the MongoDB database",
-        execution: { taskSupport: "optional" },
         inputSchema: {
           type: "object",
           properties: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ export function createServer(
     {
       name: "mongodb",
       title: "MongoDB MCP Server",
-      version: "2.1.1",
+      version: "3.0.0",
       description:
         "MCP server for MongoDB: query, aggregate, and manage collections with read-only mode, progress notifications, and cancellation",
       websiteUrl: "https://github.com/kiliczsh/mcp-mongo-server",

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ export function createServer(
   db: Db,
   isReadOnlyMode = false,
   allowCrossDb = false,
+  allowServerJs = false,
   options = {},
 ) {
   const server = new Server(
@@ -134,6 +135,7 @@ export function createServer(
       db,
       isReadOnlyMode,
       allowCrossDb,
+      allowServerJs,
       signal: ctx.mcpReq.signal,
     }),
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ export function createServer(
   client: MongoClient,
   db: Db,
   isReadOnlyMode = false,
+  allowCrossDb = false,
   options = {},
 ) {
   const server = new Server(
@@ -132,6 +133,7 @@ export function createServer(
       client,
       db,
       isReadOnlyMode,
+      allowCrossDb,
       signal: ctx.mcpReq.signal,
     }),
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,19 +1,5 @@
-import {
-  InMemoryTaskMessageQueue,
-  InMemoryTaskStore,
-} from "@modelcontextprotocol/sdk/experimental/tasks";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import {
-  CallToolRequestSchema,
-  CompleteRequestSchema,
-  GetPromptRequestSchema,
-  ListPromptsRequestSchema,
-  ListResourcesRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ListToolsRequestSchema,
-  PingRequestSchema,
-  ReadResourceRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { Server } from "@modelcontextprotocol/server";
+import type { Notification } from "@modelcontextprotocol/server";
 import type { Db, MongoClient } from "mongodb";
 import { handleCallToolRequest } from "./schemas/call.js";
 import { handleCompletionRequest } from "./schemas/completion.js";
@@ -35,22 +21,16 @@ export type SendProgressFn = (
   message?: string,
 ) => Promise<void>;
 
-function createSendProgress(extra: {
-  _meta?: { progressToken?: string | number };
-  sendNotification: (notification: {
-    method: "notifications/progress";
-    params: {
-      progressToken: string | number;
-      progress: number;
-      total?: number;
-      message?: string;
-    };
-  }) => Promise<void>;
-}): SendProgressFn | undefined {
-  const progressToken = extra._meta?.progressToken;
+// Build a progress reporter bound to the request's progressToken. Returns
+// undefined when the client did not request progress. In v2 the reporter emits
+// via the per-request notify surface (ctx.mcpReq.notify).
+function createSendProgress(
+  progressToken: string | number | undefined,
+  notify: (notification: Notification) => Promise<void>,
+): SendProgressFn | undefined {
   if (progressToken === undefined) return undefined;
   return (progress, total, message) =>
-    extra.sendNotification({
+    notify({
       method: "notifications/progress",
       params: { progressToken, progress, total, message },
     });
@@ -66,16 +46,13 @@ export function createServer(
   isReadOnlyMode = false,
   options = {},
 ) {
-  const taskStore = new InMemoryTaskStore();
-  const taskMessageQueue = new InMemoryTaskMessageQueue();
-
   const server = new Server(
     {
       name: "mongodb",
       title: "MongoDB MCP Server",
       version: "2.1.1",
       description:
-        "MCP server for MongoDB: query, aggregate, and manage collections with read-only mode, progress notifications, cancellation, and task support",
+        "MCP server for MongoDB: query, aggregate, and manage collections with read-only mode, progress notifications, and cancellation",
       websiteUrl: "https://github.com/kiliczsh/mcp-mongo-server",
       ...options,
     },
@@ -85,14 +62,7 @@ export function createServer(
         resources: {},
         tools: {},
         prompts: {},
-        tasks: {
-          list: {},
-          cancel: {},
-          requests: { tools: { call: {} } },
-        },
       },
-      taskStore,
-      taskMessageQueue,
       ...options,
     },
   );
@@ -100,97 +70,99 @@ export function createServer(
   /**
    * Handler for ping requests to check server health
    */
-  server.setRequestHandler(PingRequestSchema, (request, extra) =>
+  server.setRequestHandler('ping', (request, ctx) =>
     handlePingRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
+      signal: ctx.mcpReq.signal,
     }),
   );
 
   /**
    * Handler for listing available collections as resources.
    */
-  server.setRequestHandler(ListResourcesRequestSchema, (request, extra) =>
+  server.setRequestHandler('resources/list', (request, ctx) =>
     handleListResourcesRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
+      signal: ctx.mcpReq.signal,
     }),
   );
 
   /**
    * Handler for reading a collection's schema or contents.
    */
-  server.setRequestHandler(ReadResourceRequestSchema, (request, extra) =>
+  server.setRequestHandler('resources/read', (request, ctx) =>
     handleReadResourceRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
-      sendProgress: createSendProgress(extra),
+      signal: ctx.mcpReq.signal,
+      sendProgress: createSendProgress(
+        request.params._meta?.progressToken,
+        ctx.mcpReq.notify,
+      ),
     }),
   );
 
   /**
    * Handler that lists available tools.
    */
-  server.setRequestHandler(ListToolsRequestSchema, (request, extra) =>
+  server.setRequestHandler('tools/list', (request, ctx) =>
     handleListToolsRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
+      signal: ctx.mcpReq.signal,
     }),
   );
 
   /**
    * Handler for MongoDB tools.
    */
-  server.setRequestHandler(CallToolRequestSchema, (request, extra) => {
-    // Only enter task path when the client explicitly requests it
-    const hasTaskParams = !!(request.params as Record<string, unknown>).task;
-    return handleCallToolRequest({
+  server.setRequestHandler('tools/call', (request, ctx) =>
+    handleCallToolRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
-      taskStore: hasTaskParams ? extra.taskStore : undefined,
-      taskTtl: hasTaskParams ? extra.taskRequestedTtl : undefined,
-    });
-  });
+      signal: ctx.mcpReq.signal,
+    }),
+  );
 
   /**
    * Handler that lists available prompts.
    */
-  server.setRequestHandler(ListPromptsRequestSchema, (request, extra) =>
+  server.setRequestHandler('prompts/list', (request, ctx) =>
     handleListPromptsRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
+      signal: ctx.mcpReq.signal,
     }),
   );
 
   /**
    * Handler for collection analysis prompt.
    */
-  server.setRequestHandler(GetPromptRequestSchema, (request, extra) =>
+  server.setRequestHandler('prompts/get', (request, ctx) =>
     handleGetPromptRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
-      sendProgress: createSendProgress(extra),
+      signal: ctx.mcpReq.signal,
+      sendProgress: createSendProgress(
+        request.params._meta?.progressToken,
+        ctx.mcpReq.notify,
+      ),
     }),
   );
 
@@ -198,27 +170,27 @@ export function createServer(
    * Handler for listing templates.
    */
   server.setRequestHandler(
-    ListResourceTemplatesRequestSchema,
-    (request, extra) =>
+    'resources/templates/list',
+    (request, ctx) =>
       handleListResourceTemplatesRequest({
         request,
         client,
         db,
         isReadOnlyMode,
-        signal: extra.signal,
+        signal: ctx.mcpReq.signal,
       }),
   );
 
   /**
    * Handler for completion requests.
    */
-  server.setRequestHandler(CompleteRequestSchema, (request, extra) =>
+  server.setRequestHandler('completion/complete', (request, ctx) =>
     handleCompletionRequest({
       request,
       client,
       db,
       isReadOnlyMode,
-      signal: extra.signal,
+      signal: ctx.mcpReq.signal,
     }),
   );
 


### PR DESCRIPTION
## Summary

Migrates `mcp-mongo-server` to the **MCP SDK v2** while keeping full backward compatibility, and layers on a round of security hardening and two new capabilities.

Pins **`@modelcontextprotocol/*@^2.0.0` (stable)** and releases as **`3.0.0`** (major — see *Breaking changes*).

## What changed

### Protocol / SDK
- **Migrate to MCP SDK v2** (scoped packages: `@modelcontextprotocol/server`, `/node`, `/express`). Uses `serveStdio` for stdio and `createMcpHandler` + `toNodeHandler` for HTTP.
- **Dual-era protocol support** — negotiates the `2026-07-28` protocol while still serving legacy `2025-11-25` clients, so existing integrations keep working.
- Error semantics aligned with the newer spec: validation/lookup misses surface as `InvalidParams` (`-32602`) via `ProtocolError` instead of the legacy `-32002`.
- Dropped the forced secondary `readPreference` in read-only mode (was silently steering reads to secondaries).

### Security hardening (all opt-in, safe by default)
- **Cross-database scoping** — aggregation pipelines are pinned to the connected database. Cross-db targets (`$lookup`/`$out`/`$merge` into another db) are rejected unless `--allow-cross-db` (`MCP_MONGODB_ALLOW_CROSS_DB`).
- **Server-side JavaScript blocked by default** — `$where`, `$function`, `$accumulator`, `mapReduce` require `--allow-server-js` (`MCP_MONGODB_ALLOW_SERVER_JS`).
- **System-collection guard** hardened (case-insensitive `system.*` match) for both tools and resources.
- **HTTP body limit** made configurable (`--json-limit` / `MCP_HTTP_JSON_LIMIT`); oversized/malformed bodies return a proper JSON-RPC error instead of a raw stack.
- **Nesting-depth guard** on the aggregation operator scan to prevent stack overflow on deeply nested input.
- **Optional bearer-token auth** for the HTTP transport (`--auth-token` / `MCP_HTTP_AUTH_TOKEN`), constant-time comparison, no separate auth server needed.

### Features & fixes
- **`convertTime` tool** — converts a Unix timestamp or date string into UTC ISO 8601 / GMT / Unix seconds & ms, and reports the server's current time and timezone. Helps build unambiguous date queries across timezones. Date filters now honor explicit timezone offsets.
- **`sort` parameter fix** — the `query` tool now declares `sort` in its input schema; previously the SDK stripped it, so sorts were silently ignored.
- **`createIndex` result fix** — the driver returns the created index names (`string[]`), not the object the handler assumed, so success responses came back as an empty `{}`. Now returns `{ acknowledged, createdIndexes, indexCount }`.

### Docs
- README + `docs/` updated: HTTP transport, all new flags/env vars, security section, `convertTime`, bearer auth, corrected read-only behavior.

## Breaking changes (why `3.0.0`)
- Runs on the MCP SDK v2 line and negotiates the `2026-07-28` protocol (legacy `2025-11-25` clients still supported).
- Default-safe posture is stricter: cross-database targets and server-side JavaScript are now rejected unless explicitly enabled via the new flags.
- Minimum MongoDB server version is **4.2+** (modern driver requirement) — older servers (wire version < 8) can no longer be connected.

## Validation
- Working tree clean; `build` and `biome lint` pass (0 warnings).
- All 9 tools verified end-to-end against a live MongoDB 8.2 replica set (`serverInfo`, `listCollections`, `count`, `query` incl. sort, `aggregate`, `insert`, `update`, `createIndex`, `convertTime`).
- Verified across the compatibility matrix (standalone 4.4 / 6.0 / 7.0, replica set 8.2, TLS, no-auth) over both stdio and HTTP transports.
- `bun audit`: 3 moderate advisories (`ajv` ReDoS via `$data`) — transitive through the SDK, not exercised by this code.
