### PR TITLE
fix: rename npx bin to mcp-mongo-server (v3.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-mongo-server",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Model Context Protocol server for MongoDB connections",
   "private": false,
   "type": "module",
@@ -8,7 +8,7 @@
     "node": ">=20"
   },
   "bin": {
-    "mongodb": "./build/index.js"
+    "mcp-mongo-server": "./build/index.js"
   },
   "files": [
     "build"

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ export function createServer(
     {
       name: "mongodb",
       title: "MongoDB MCP Server",
-      version: "3.0.0",
+      version: "3.0.1",
       description:
         "MCP server for MongoDB: query, aggregate, and manage collections with read-only mode, progress notifications, and cancellation",
       websiteUrl: "https://github.com/kiliczsh/mcp-mongo-server",


### PR DESCRIPTION
## Summary

Renames the CLI bin from `mongodb` to `mcp-mongo-server` so `npx` resolves it directly. Patch release **`3.0.1`**.

## Why

The package name is `mcp-mongo-server`, but the bin was named `mongodb`. When the package name and bin name differ, `npx -y mcp-mongo-server "<connection-string>"` (the form documented in the README) fails to resolve the single bin and errors with:

```
sh: mongodb: command not found
```

The only working invocation was the explicit `npx -y -p mcp-mongo-server mongodb "<connection-string>"`, which is awkward and undocumented.

## Change

- `package.json` bin: `mongodb` → `mcp-mongo-server`.
- Version bump `3.0.0` → `3.0.1` (also updated in the server handshake in `src/server.ts`).

After this release, `npx -y mcp-mongo-server "<connection-string>"` — exactly what the README shows — works out of the box, no `-p` needed.

## Notes

- The README already documents the `npx -y mcp-mongo-server …` form, so no docs change is required.
- Verified: the built server starts and connects over stdio (`Connected to MongoDB database … Server connected successfully via stdio`).
